### PR TITLE
Allow documentation as a project report

### DIFF
--- a/src/site/sphinx/basic-usage.rst
+++ b/src/site/sphinx/basic-usage.rst
@@ -34,6 +34,9 @@ For good examples of documentation, see `Sphinx' examples page`_.
 Executing within ``site`` lifecycle
 ===================================
 
+Overriding default Maven site
+-----------------------------
+
 Simply add the sphinx-maven-plugin to your ``pom.xml``:
 
 .. parsed-literal::
@@ -70,6 +73,40 @@ Now all you need to do is to generate the documentation::
   mvn site
 
 This will generate the documentation in the `target/site` folder.
+
+Generating documentation as a project report
+--------------------------------------------
+
+You can also generate the documentation as a project report in Maven default site :
+
+.. parsed-literal::
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+      </plugin>
+      <plugin>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>sphinx-maven-plugin</artifactId>
+        <version>\ |release|\ </version>
+        <asReport>true</asReport>
+        <name>Project documentation</name>
+        <description>Documentation about ${project.name}</description>
+      </plugin>
+    </plugins>
+  </reporting>
+
+Then :
+
+::
+
+  mvn site
+
+This will generate the documentation in the `target/site/sphinx` folder without affecting default Maven site (remains
+in `target/site`). You can access the documentation through "Project reports" in Maven site menu bar.
 
 Executing within normal lifecycle
 =================================

--- a/src/site/sphinx/basic-usage.rst
+++ b/src/site/sphinx/basic-usage.rst
@@ -92,9 +92,11 @@ You can also generate the documentation as a project report in Maven default sit
         <groupId>kr.motd.maven</groupId>
         <artifactId>sphinx-maven-plugin</artifactId>
         <version>\ |release|\ </version>
-        <asReport>true</asReport>
-        <name>Project documentation</name>
-        <description>Documentation about ${project.name}</description>
+        <configuration>
+          <asReport>true</asReport>
+          <name>Project documentation</name>
+          <description>Documentation about ${project.name}</description>
+        </configuration>
       </plugin>
     </plugins>
   </reporting>

--- a/src/site/sphinx/configuration.rst
+++ b/src/site/sphinx/configuration.rst
@@ -21,6 +21,7 @@ Parameter                Description                                            
 ``warningsAsErrors``     Whether warnings should be treated as errors.                                                     ``false``
 ``force``                Whether Sphinx should generate output for all files instead of only the changed ones.             ``false``
 ``tags``                 Additional tags to pass to Sphinx. See the `Sphinx tag documentation`_ for more information.
+``asReport``             Whether documentation should be generated as a project report (keep default Maven site).          ``false``
 ======================== ================================================================================================= ========================================
 
 Using PlantUML

--- a/src/site/sphinx/index.rst
+++ b/src/site/sphinx/index.rst
@@ -44,6 +44,10 @@ This plugin was originally written by `Thomas Dudziak`_. `Bala Sridhar`_ since t
 and added PlantUML and JavaSphinx support in his fork. I'd like to appreciate their effort that did all the
 heavy lifting. This fork includes the following additional changes:
 
+1.3.2.Final-SNAPSHOT (12-Aug-2016)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Possibility to keep default Maven site + put documentation in "Project reports" when plugin is specified as a reporting plugin
+
 1.3.1.Final (25-Apr-2016)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - The line separators of the generated text files are now converted to the line separator of the current platform, so that the version control systems like Git do not complain about inconsistent line endings.


### PR DESCRIPTION
Hi !

In a project I needed to keep the default generated Maven site, but with a link to the Sphinx documentation. I know this was possible to keep default site by overriding `outputDirectory`, but I was a little upset no link was generated on Maven default site (due to the fact that the plugin is declared in build plugins).

So I decided to fix this with a new version; now it's possible to declare documentation as a report (with `asReport` option in the plugin), and the link to the default site is created in "Project reports".

*Configuration*

```xml
<reporting>
    <plugins>
        <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-project-info-reports-plugin</artifactId>
            <version>2.9</version>
        </plugin>

        <plugin>
            <groupId>kr.motd.maven</groupId>
            <artifactId>sphinx-maven-plugin</artifactId>
            <version>1.3.2.Final-SNAPSHOT</version>
            <configuration>
                <asReport>true</asReport>
                <name>Project documentation</name>
                <description>My Sphinx documentation</description>
            </configuration>
        </plugin>
    </plugins>
</reporting>
```

*Result*

<img width="762" alt="generated_reports" src="https://cloud.githubusercontent.com/assets/17676154/17624827/8fafccd2-60a6-11e6-8d10-eb2590e540a3.png">

I updated the documentation and made some tests, it seems to work without modifying the behavior of previous versions. I'm waiting for your comments. :)

@jnorb