### PR TITLE
Add skip option and "sphinx.skip" property to skip plugin execution

### DIFF
--- a/src/main/java/kr/motd/maven/sphinx/SphinxMojo.java
+++ b/src/main/java/kr/motd/maven/sphinx/SphinxMojo.java
@@ -114,8 +114,19 @@ public class SphinxMojo extends AbstractMojo implements MavenReport {
     @Parameter(property = "sphinx.force", defaultValue = "false", required = true, alias = "force")
     private boolean force;
 
+    /**
+     * Whether Sphinx execution should be skipped.
+     */
+    @Parameter(property = "sphinx.skip", defaultValue = "false", required = true, alias = "skip")
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("Skipping Sphinx execution.");
+            return;
+        }
+
         sourceDirectory = canonicalize(sourceDirectory);
         outputDirectory = canonicalize(outputDirectory);
         sphinxSourceDirectory = canonicalize(sphinxSourceDirectory);

--- a/src/site/sphinx/configuration.rst
+++ b/src/site/sphinx/configuration.rst
@@ -22,6 +22,7 @@ Parameter                Description                                            
 ``force``                Whether Sphinx should generate output for all files instead of only the changed ones.             ``false``
 ``tags``                 Additional tags to pass to Sphinx. See the `Sphinx tag documentation`_ for more information.
 ``asReport``             Whether documentation should be generated as a project report (keep default Maven site).          ``false``
+``skip``                 Whether Sphinx execution should be skipped.                                                       ``false``
 ======================== ================================================================================================= ========================================
 
 Using PlantUML


### PR DESCRIPTION
In some cases it might be useful to skip the plugin execution, e. g. in a build profile.

This change set adds the boolean "skip" option (override via "sphinx.skip" property) which
allows to skip the plugin execution in Maven.